### PR TITLE
fix: Use fallback when state.articles is undefined

### DIFF
--- a/client/src/reducers/articleList.js
+++ b/client/src/reducers/articleList.js
@@ -18,7 +18,7 @@ export default (state = {}, action) => {
     case ARTICLE_UNFAVORITED:
       return {
         ...state,
-        articles: state.articles.map(article => {
+        articles: (state.articles || []).map(article => {
           if (article.slug === action.payload.article.slug) {
             return {
               ...article,


### PR DESCRIPTION
This seems to be failing `new-post-spec.js` pretty frequently. Example here: https://app.circleci.com/pipelines/github/cypress-io/cypress-test-example-repos/8077/workflows/16d2c61b-af57-404a-b4eb-9616bf49c8be/jobs/191295
